### PR TITLE
sync ws example README with rsocket v0.5.1

### DIFF
--- a/rsocket-transport-websocket/README.md
+++ b/rsocket-transport-websocket/README.md
@@ -6,35 +6,41 @@ Add dependencies in your `Cargo.toml`.
 
 ```toml
 [dependencies]
-tokio = "0.2.11"
-rsocket_rust = "0.5.0"
-
-# choose transport:
-# rsocket_rust_transport_tcp = "0.5.0"
-# rsocket_rust_transport_websocket = "0.5.0"
+tokio = "0.2.16"
+rsocket_rust = "0.5.1"
+rsocket_rust_transport_websocket = "0.5.1"
 ```
 
 ### Server
 
 ```rust
-use rsocket_rust::prelude::*;
+use log::info;
+use rsocket_rust::prelude::{EchoRSocket, RSocketFactory, ServerResponder};
 use rsocket_rust_transport_websocket::WebsocketServerTransport;
-use std::env;
 use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let transport: WebsocketServerTransport = WebsocketServerTransport::from("127.0.0.1:8080");
+
+    let responder: ServerResponder = Box::new(|setup, _socket| {
+        info!("accept setup: {:?}", setup);
+        Ok(Box::new(EchoRSocket))
+        // Or you can reject setup
+        // Err(From::from("SETUP_NOT_ALLOW"))
+    });
+
+    let on_start: Box<dyn FnMut() + Send + Sync> =
+        Box::new(|| info!("+++++++ echo server started! +++++++"));
+
     RSocketFactory::receive()
-        .transport(WebsocketServerTransport::from("127.0.0.1:8080"))
-        .acceptor(|setup, _socket| {
-            println!("accept setup: {:?}", setup)
-            Ok(Box::new(EchoRSocket))
-            // Or you can reject setup
-            // Err(From::from("SETUP_NOT_ALLOW"))
-        })
-        .on_start(|| println!("+++++++ echo server started! +++++++"))
+        .transport(transport)
+        .acceptor(responder)
+        .on_start(on_start)
         .serve()
-        .await
+        .await?;
+
+    Ok(())
 }
 
 ```
@@ -42,27 +48,36 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 ### Client
 
 ```rust
-use rsocket_rust::prelude::*;
+use log::info;
+use rsocket_rust::prelude::{ClientResponder, EchoRSocket, Payload, RSocket, RSocketFactory};
 use rsocket_rust_transport_websocket::WebsocketClientTransport;
+use std::error::Error;
 
 #[tokio::main]
-#[test]
-async fn test() {
-    let cli = RSocketFactory::connect()
-        .acceptor(|| Box::new(EchoRSocket))
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let responder: ClientResponder = Box::new(|| Box::new(EchoRSocket));
+
+    let client = RSocketFactory::connect()
+        .acceptor(responder)
         .transport(WebsocketClientTransport::from("127.0.0.1:8080"))
         .setup(Payload::from("READY!"))
         .mime_type("text/plain", "text/plain")
         .start()
         .await
         .unwrap();
-    let req = Payload::builder()
+
+    let request_payload: Payload = Payload::builder()
         .set_data_utf8("Hello World!")
         .set_metadata_utf8("Rust")
         .build();
-    let res = cli.request_response(req).await.unwrap();
-    println!("got: {:?}", res);
-    cli.close();
+
+    let res = client.request_response(request_payload).await.unwrap();
+
+    info!("got: {:?}", res);
+
+    client.close();
+
+    Ok(())
 }
 
 ```


### PR DESCRIPTION
- now the library version is 0.5.1
- added type annotations, which I think makes it a little easier to understand the code in the example