### PR TITLE
Use Rust 2021 edition

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples"
 version = "0.0.0"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/rsocket-messaging/Cargo.toml
+++ b/rsocket-messaging/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust_messaging"
 version = "0.7.2"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rsocket/rsocket-rust"

--- a/rsocket-test/Cargo.toml
+++ b/rsocket-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust_test"
 version = "0.0.0"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dev-dependencies]

--- a/rsocket-transport-tcp/Cargo.toml
+++ b/rsocket-transport-tcp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust_transport_tcp"
 version = "0.7.2"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rsocket/rsocket-rust"

--- a/rsocket-transport-wasm/Cargo.toml
+++ b/rsocket-transport-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust_transport_wasm"
 version = "0.7.2"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rsocket/rsocket-rust"

--- a/rsocket-transport-websocket/Cargo.toml
+++ b/rsocket-transport-websocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust_transport_websocket"
 version = "0.7.3"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rsocket/rsocket-rust"

--- a/rsocket/Cargo.toml
+++ b/rsocket/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rsocket_rust"
 version = "0.7.2"
 authors = ["Jeffsky <jjeffcaii@outlook.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rsocket/rsocket-rust"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2018"
+edition = 2021"
 group_imports="StdExternalCrate"


### PR DESCRIPTION
_Use Rust 2021 edition_

### Motivation:

_Rust 2021 is out since October 2021._

### Modifications:

_Update  the `edition` manifest section to `2021`_

### Result:

_Should work as before_
