### PR TITLE
Make `clippy` happy

### DIFF
--- a/rsocket-messaging/src/lib.rs
+++ b/rsocket-messaging/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 mod misc;
 mod requester;
 

--- a/rsocket-messaging/src/requester.rs
+++ b/rsocket-messaging/src/requester.rs
@@ -36,6 +36,7 @@ pub struct RequestSpec {
     data: Option<FnData>,
 }
 
+#[derive(Default)]
 pub struct RequesterBuilder {
     data_mime_type: Option<MimeType>,
     route: Option<String>,
@@ -50,18 +51,6 @@ pub struct Unpackers {
 
 pub struct Unpacker {
     inner: UnpackerResult,
-}
-
-impl Default for RequesterBuilder {
-    fn default() -> Self {
-        Self {
-            data_mime_type: None,
-            route: None,
-            metadata: Default::default(),
-            data: None,
-            tp: None,
-        }
-    }
 }
 
 impl RequesterBuilder {
@@ -371,9 +360,9 @@ where
     match mime_type.as_u8() {
         Some(code) => {
             if code == MimeType::APPLICATION_JSON.as_u8().unwrap() {
-                Ok(Some(unmarshal(misc::json(), &raw.as_ref())?))
+                Ok(Some(unmarshal(misc::json(), raw.as_ref())?))
             } else if code == MimeType::APPLICATION_CBOR.as_u8().unwrap() {
-                Ok(Some(unmarshal(misc::cbor(), &raw.as_ref())?))
+                Ok(Some(unmarshal(misc::cbor(), raw.as_ref())?))
             } else {
                 Err(RSocketError::WithDescription("unsupported mime type!".into()).into())
             }

--- a/rsocket-transport-wasm/src/connection.rs
+++ b/rsocket-transport-wasm/src/connection.rs
@@ -19,7 +19,7 @@ impl Connection for WebsocketConnection {
     fn split(self) -> (Box<FrameSink>, Box<FrameStream>) {
         (
             Box::new(self.tx.sink_map_err(|e| RSocketError::Other(e.into()))),
-            Box::new(self.rx.map(|it| Ok(it))),
+            Box::new(self.rx.map(Ok)),
         )
     }
 }

--- a/rsocket-transport-wasm/src/lib.rs
+++ b/rsocket-transport-wasm/src/lib.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::type_complexity)]
+#![allow(clippy::unused_unit)]
+#![allow(clippy::from_over_into)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/rsocket-transport-websocket/src/connection.rs
+++ b/rsocket-transport-websocket/src/connection.rs
@@ -72,7 +72,7 @@ impl Connection for WebsocketConnection {
                     bf.put_slice(&raw[..]);
                     match Frame::decode(&mut bf) {
                         Ok(frame) => Ok(frame),
-                        Err(e) => Err(RSocketError::Other(e.into())),
+                        Err(e) => Err(RSocketError::Other(e)),
                     }
                 }
                 Err(e) => Err(RSocketError::Other(e.into())),

--- a/rsocket/src/extension/mime.rs
+++ b/rsocket/src/extension/mime.rs
@@ -44,10 +44,7 @@ impl MimeType {
     pub fn as_str(&self) -> Option<&str> {
         match self {
             Self::Normal(s) => Some(s.as_ref()),
-            Self::WellKnown(n) => match U8_TO_STR.get(n) {
-                Some(v) => Some(v),
-                None => None,
-            },
+            Self::WellKnown(n) => U8_TO_STR.get(n).copied(),
         }
     }
 }

--- a/rsocket/src/lib.rs
+++ b/rsocket/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::from_over_into)]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))


### PR DESCRIPTION
_Make `clippy` happy_

### Motivation:

Fix existing `clippy` issues so newly introduced issues are easier to detect. 

The specific `clippy` command used was

```
cargo +nightly clippy --all-features
```
New `clippy` lints to get added frequently, hence using `nightly`

### Modifications:

- Fix issues according to `clippy` suggestions
- Ignore all the `clippy::from_over_into` into issues.  

I think over time, we should strive to fix the currently ignored `clippy` issues as well. IMO, `clippy` is really helpful to maintain idiomatic code and the few false-positive could be easily manged.

### Result:

No more complains from `clippy`
