### PR TITLE
feat: add support for wss (TLS) connections for clients

### DIFF
--- a/rsocket-transport-websocket/Cargo.toml
+++ b/rsocket-transport-websocket/Cargo.toml
@@ -14,7 +14,10 @@ log = "0.4.14"
 futures = "0.3.15"
 bytes = "1.0.1"
 url = "2.2.2"
-tokio-tungstenite = "0.13.0"
+
+[dependencies.tokio-tungstenite]
+version = "0.18.0"
+features = ["native-tls"]
 
 [dependencies.rsocket_rust]
 version = "0.7"

--- a/rsocket-transport-websocket/src/connection.rs
+++ b/rsocket-transport-websocket/src/connection.rs
@@ -10,6 +10,7 @@ use rsocket_rust::{
     utils::Writeable,
 };
 use tokio::net::TcpStream;
+use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::{
     tungstenite::{Error as WsError, Message},
     WebSocketStream,
@@ -17,16 +18,16 @@ use tokio_tungstenite::{
 
 #[derive(Debug)]
 pub struct WebsocketConnection {
-    stream: WebSocketStream<TcpStream>,
+    stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
 }
 
 impl WebsocketConnection {
-    pub(crate) fn new(stream: WebSocketStream<TcpStream>) -> WebsocketConnection {
+    pub(crate) fn new(stream: WebSocketStream<MaybeTlsStream<TcpStream>>) -> WebsocketConnection {
         WebsocketConnection { stream }
     }
 }
 
-struct InnerSink(SplitSink<WebSocketStream<TcpStream>, Message>);
+struct InnerSink(SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>);
 
 impl Sink<Frame> for InnerSink {
     type Error = WsError;

--- a/rsocket-transport-websocket/src/lib.rs
+++ b/rsocket-transport-websocket/src/lib.rs
@@ -14,16 +14,17 @@ pub use server::WebsocketServerTransport;
 mod test_websocket {
     use super::*;
     use rsocket_rust::prelude::*;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 
     #[ignore]
     #[tokio::test]
     async fn test_client() {
-        let req: WebsocketRequest = WebsocketRequest::builder()
-            .uri("ws://127.0.0.1:8080/hello")
-            .header("x-foo-bar", "42")
-            .method("GET")
-            .body(())
-            .unwrap();
+        let mut req = "ws://127.0.0.1:8080/hello".into_client_request().unwrap();
+
+        // Optional: custom headers
+        let headers = req.headers_mut();
+        headers.insert("x-foo-bar", "42".parse().unwrap());
+
         let tp = WebsocketClientTransport::from(req);
         let c = RSocketFactory::connect()
             .transport(tp)


### PR DESCRIPTION
Add TLS support for RSocket WebSocket transport for client connections.

### Motivation

TLS support is required for many real-world use-cases, including my specific use case. For anyone who wants to use this library and must connect via TLS, this is a must.

### Modifications

1. Wrapped `TcpStream`s in `MaybeTlsStream` and that is 99% of the work. tokio-tungstenite already supports TLS so it was just making it usable with the interface.
2. The way headers are handled changed a bit due to changes in the underlying tokio-tungstenite `Request` object. I updated the example in the lib.rs file to match.

### Result

rsocket-rust's websocket transport supports TLS connections with most of the heavy lifting being done by the underlying tokio-tungstenite.

### See

Issue: #61 